### PR TITLE
Fix errors with download

### DIFF
--- a/App/Commands/PwDownload.php
+++ b/App/Commands/PwDownload.php
@@ -39,8 +39,7 @@ class PwDownload extends Command {
     $this->write("Cleaning up temporary files...");
     $this->exec("rm $version.zip");
     $this->exec("mv processwire-$version pwtmp");
-    $this->exec('mv pwtmp/* ./');
-    $this->exec('mv pwtmp/.* ./');
+    $this->exec('find pwtmp -mindepth 1 -maxdepth 1 -exec mv -t ./ {} +');
     
     sleep(1);
     $this->exec("rm -rf pwtmp");


### PR DESCRIPTION
Prevents the errors
`mv: cannot move 'pwtmp/.' to './.': Device or resource busy` and  `mv: cannot move 'pwtmp/..' to './..': Device or resource busy` when using `pw:download`

The error occurs because we try to move the special directories "." and ".." which represent the current directory and the parent directory respectively. This operation is not allowed, hence the error.